### PR TITLE
Market Observatory: deterministic simulation, 3D scene, HUD, controls, and replay store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.dist
+.DS_Store
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# RYA-CAM
+# Market Observatory
+
+A futuristic, quant-grade single-page UI that simulates stochastic probability fields, regime drift, and multi-asset confluence for the top NASDAQ-weighted names.
+
+## Module structure & state schema (plan)
+
+**Modules**
+- `src/simulation/*` — deterministic simulation seed, stochastic distributions, regimes, confluence engine, and probability field point cloud.
+- `src/store/useMarketStore.ts` — state store, controls, replay buffer, and tick scheduler.
+- `src/components/*` — 3D renderer (Three.js via react-three-fiber), HUD overlays, controls, and timeline scrubber.
+- `src/App.tsx` — layout + wiring between simulation and UI.
+
+**State schema (high-level)**
+- `SimulationState`: entropy, kurtosis, tail risk, distribution clusters, horizon fan quantiles, regime probabilities + transition risk, confluence contributions, and point field positions.
+- `SimulationControls`: factor weights, regime sensitivity, horizon focus, stress-test dial.
+- `SimulationSnapshot`: timestamp + state for replay.
+
+## Run locally
+
+```bash
+npm install
+npm run dev
+```
+
+## Extend with real-time market data
+
+The simulation functions in `src/simulation/` are structured so you can swap in real feeds:
+- Replace `createSimulation()` with a data adapter that maps incoming ticks to the same `SimulationState` shape.
+- Maintain deterministic replay by persisting incoming updates in `SimulationSnapshot` history.
+- Confluence factors (`correlationShift`, `volOfVol`, `breadth`, `sentimentShock`, `liquidity`) already have explicit keys; plug in real signals without UI changes.
+
+## Notes
+- No external APIs are used; all visuals are simulated with a deterministic seed.
+- Performance considerations include point field instancing, throttled simulation ticks, and minimal re-renders.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Market Observatory</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "market-observatory",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@react-three/drei": "^9.115.0",
+    "@react-three/fiber": "^8.16.8",
+    "@react-three/postprocessing": "^2.16.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.167.1",
+    "zustand": "^4.5.4"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useMemo } from 'react';
+import { ControlsPanel } from './components/ControlsPanel';
+import { Hud } from './components/Hud';
+import { ThreeScene } from './components/ThreeScene';
+import { Timeline } from './components/Timeline';
+import { useMarketStore } from './store/useMarketStore';
+
+const App = () => {
+  const tick = useMarketStore((state) => state.tick);
+  const history = useMarketStore((state) => state.history);
+  const selectedIndex = useMarketStore((state) => state.selectedIndex);
+  const live = useMarketStore((state) => state.live);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      tick();
+    }, 220);
+    return () => window.clearInterval(id);
+  }, [tick]);
+
+  const simulation = useMemo(() => {
+    if (live) {
+      return history[history.length - 1].state;
+    }
+    return history[selectedIndex]?.state ?? history[history.length - 1].state;
+  }, [history, selectedIndex, live]);
+
+  return (
+    <div className="app">
+      <ControlsPanel />
+      <div className="canvas-wrap">
+        <ThreeScene simulation={simulation} />
+        <Hud simulation={simulation} />
+        <div style={{ position: 'absolute', left: 24, bottom: 24, width: 320 }}>
+          <Timeline />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -1,0 +1,110 @@
+import { SimulationControls } from '../simulation/types';
+import { useMarketStore } from '../store/useMarketStore';
+
+const factorLabels: Record<keyof SimulationControls['weightConfig'], string> = {
+  correlationShift: 'Correlation Shift',
+  volOfVol: 'Vol-of-Vol',
+  breadth: 'Breadth',
+  sentimentShock: 'Sentiment Shock',
+  liquidity: 'Liquidity',
+};
+
+export const ControlsPanel = () => {
+  const controls = useMarketStore((state) => state.controls);
+  const setControl = useMarketStore((state) => state.setControl);
+  const setWeight = useMarketStore((state) => state.setWeight);
+  const live = useMarketStore((state) => state.live);
+  const toggleLive = useMarketStore((state) => state.toggleLive);
+
+  return (
+    <div className="panel">
+      <h1>Market Observatory</h1>
+      <section>
+        <label>Confluence Weights</label>
+        {Object.entries(controls.weightConfig).map(([key, value]) => (
+          <div key={key}>
+            <div className="toggle-row">
+              <span className="badge">{factorLabels[key as keyof typeof factorLabels]}</span>
+              <span>{value.toFixed(2)}</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={2}
+              step={0.05}
+              value={value}
+              onChange={(event) => setWeight(key as keyof typeof controls.weightConfig, Number(event.target.value))}
+            />
+          </div>
+        ))}
+      </section>
+      <section>
+        <label>Regime Sensitivity</label>
+        <div className="toggle-row">
+          <span className="badge">Drift Gain</span>
+          <span>{controls.regimeSensitivity.toFixed(2)}</span>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={1.2}
+          step={0.05}
+          value={controls.regimeSensitivity}
+          onChange={(event) => setControl('regimeSensitivity', Number(event.target.value))}
+        />
+      </section>
+      <section>
+        <label>Horizon Focus</label>
+        <div className="toggle-row">
+          <span className="badge">{controls.horizon}</span>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={2}
+          step={1}
+          value={['5m', '1h', '1d'].indexOf(controls.horizon)}
+          onChange={(event) => {
+            const options: Array<'5m' | '1h' | '1d'> = ['5m', '1h', '1d'];
+            setControl('horizon', options[Number(event.target.value)]);
+          }}
+        />
+      </section>
+      <section>
+        <label>Stress Test Scenario</label>
+        <div className="toggle-row">
+          <span className="badge">Liquidity Vacuum</span>
+          <span>{controls.stressTest.toFixed(2)}</span>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.05}
+          value={controls.stressTest}
+          onChange={(event) => setControl('stressTest', Number(event.target.value))}
+        />
+      </section>
+      <section>
+        <label>Replay Mode</label>
+        <div className="toggle-row">
+          <span className="badge">{live ? 'Live' : 'Scrub'}</span>
+          <button
+            type="button"
+            onClick={toggleLive}
+            style={{
+              background: 'transparent',
+              border: '1px solid rgba(120, 170, 255, 0.3)',
+              color: '#9db9ff',
+              padding: '6px 12px',
+              borderRadius: 12,
+              cursor: 'pointer',
+            }}
+          >
+            {live ? 'Pause' : 'Resume'}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -1,0 +1,73 @@
+import { SimulationState } from '../simulation/types';
+
+interface HudProps {
+  simulation: SimulationState;
+}
+
+export const Hud = ({ simulation }: HudProps) => {
+  const dominantRegime = Object.entries(simulation.regime.probabilities).sort((a, b) => b[1] - a[1])[0];
+
+  return (
+    <div className="hud">
+      <div className="hud-card">
+        <div className="hud-title">Regime Drift</div>
+        <div className="stat-grid">
+          <div className="stat-row">
+            <span>Dominant</span>
+            <span>{dominantRegime?.[0]}</span>
+          </div>
+          <div className="stat-row">
+            <span>Transition Risk</span>
+            <span>{simulation.regime.transitionRisk.toFixed(2)}</span>
+          </div>
+          <div className="regime-bar">
+            <div
+              className="regime-fill"
+              style={{ width: `${Math.min(simulation.regime.transitionRisk * 100, 100)}%` }}
+            />
+          </div>
+        </div>
+      </div>
+      <div className="hud-card">
+        <div className="hud-title">Tail Event Forming</div>
+        <div className="stat-grid">
+          <div className="stat-row">
+            <span>Entropy</span>
+            <span>{simulation.entropy.toFixed(2)}</span>
+          </div>
+          <div className="stat-row">
+            <span>Kurtosis</span>
+            <span>{simulation.kurtosis.toFixed(2)}</span>
+          </div>
+          <div className="stat-row">
+            <span>Tail Risk</span>
+            <span>{simulation.tailRisk.toFixed(2)}</span>
+          </div>
+        </div>
+      </div>
+      <div className="hud-card">
+        <div className="hud-title">Confluence Engine</div>
+        <div className="stat-grid">
+          <div className="stat-row">
+            <span>Total Score</span>
+            <span>{simulation.confluence.total.toFixed(2)}</span>
+          </div>
+          <div className="confluence-list">
+            {simulation.confluence.contributions.map((item) => (
+              <div className="confluence-item" key={item.ticker}>
+                <span>{item.ticker}</span>
+                <span>{item.score.toFixed(2)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="hud-card">
+        <div className="hud-title">Signal Glossary</div>
+        <div className="legend">
+          Fan cones = horizon quantiles. Halo deformation = transition risk. Edge shadow = tail risk.
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ThreeScene.tsx
+++ b/src/components/ThreeScene.tsx
@@ -1,0 +1,128 @@
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { Bloom, EffectComposer } from '@react-three/postprocessing';
+import { OrbitControls, Stars } from '@react-three/drei';
+import { useMemo, useRef } from 'react';
+import { Mesh, Points, AdditiveBlending, Color, BufferAttribute } from 'three';
+import { SimulationState } from '../simulation/types';
+import { useMarketStore } from '../store/useMarketStore';
+
+interface SceneProps {
+  simulation: SimulationState;
+}
+
+const ProbabilityField = ({ simulation }: SceneProps) => {
+  const pointsRef = useRef<Points>(null);
+  const sphereRef = useRef<Mesh>(null);
+  const ringRef = useRef<Mesh>(null);
+  const { camera } = useThree();
+  const activeHorizon = useMarketStore((state) => state.controls.horizon);
+
+  const geometry = useMemo(() => {
+    const positions = simulation.pointField;
+    return new BufferAttribute(positions, 3);
+  }, [simulation.pointField]);
+
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime();
+    const stress = simulation.tailRisk;
+    if (sphereRef.current) {
+      sphereRef.current.rotation.y = t * (0.12 - stress * 0.08);
+      sphereRef.current.rotation.x = t * (0.08 - stress * 0.05);
+      sphereRef.current.scale.setScalar(1 + Math.sin(t * 0.6) * 0.02 + stress * 0.05);
+    }
+    if (ringRef.current) {
+      ringRef.current.rotation.z = t * 0.2;
+      ringRef.current.scale.setScalar(1.4 + simulation.regime.transitionRisk * 0.3);
+    }
+    if (camera) {
+      camera.position.x = Math.sin(t * 0.1) * 0.6;
+      camera.position.y = 0.6 + Math.cos(t * 0.08) * 0.2;
+      camera.lookAt(0, 0, 0);
+    }
+  });
+
+  return (
+    <group>
+      <points ref={pointsRef}>
+        <bufferGeometry>
+          <bufferAttribute
+            attach="attributes-position"
+            array={geometry.array}
+            count={geometry.count}
+            itemSize={geometry.itemSize}
+          />
+        </bufferGeometry>
+        <pointsMaterial
+          size={0.035}
+          color={new Color('#7ef9ff')}
+          opacity={0.6}
+          transparent
+          blending={AdditiveBlending}
+          depthWrite={false}
+        />
+      </points>
+      <mesh ref={sphereRef}>
+        <sphereGeometry args={[0.6, 64, 64]} />
+        <meshStandardMaterial
+          color={'#2b6bff'}
+          emissive={'#8dd0ff'}
+          emissiveIntensity={0.4}
+          roughness={0.3}
+          metalness={0.4}
+          transparent
+          opacity={0.35}
+        />
+      </mesh>
+      <mesh ref={ringRef}>
+        <torusGeometry args={[0.9, 0.04 + simulation.regime.transitionRisk * 0.05, 32, 200]} />
+        <meshStandardMaterial
+          color={'#ff9bcf'}
+          emissive={'#7ef9ff'}
+          emissiveIntensity={0.5}
+          transparent
+          opacity={0.6}
+        />
+      </mesh>
+      {simulation.fans.map((fan, index) => (
+        <mesh key={fan.horizon} rotation={[Math.PI / 2, 0, (index * Math.PI) / 3]}>
+          <coneGeometry args={[fan.quantiles[2] + 0.2, 1.6, 32, 1, true]} />
+          <meshStandardMaterial
+            color={'#7a8cff'}
+            transparent
+            opacity={fan.horizon === activeHorizon ? 0.45 : 0.12 + index * 0.04}
+            wireframe
+          />
+        </mesh>
+      ))}
+      <mesh rotation={[Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[0.7, 0.72, 64]} />
+        <meshBasicMaterial
+          color={'#ff5f9e'}
+          transparent
+          opacity={0.3 + simulation.tailRisk * 0.4}
+          blending={AdditiveBlending}
+        />
+      </mesh>
+    </group>
+  );
+};
+
+export const ThreeScene = ({ simulation }: SceneProps) => {
+  return (
+    <Canvas
+      camera={{ position: [0, 0.6, 2.2], fov: 55 }}
+      style={{ background: 'radial-gradient(circle at center, #0a1628, #05070c 70%)' }}
+    >
+      <fog attach="fog" args={['#05070c', 2, 6]} />
+      <ambientLight intensity={0.5} />
+      <pointLight position={[2, 2, 2]} intensity={1.4} color={'#7ef9ff'} />
+      <pointLight position={[-2, -1, 1]} intensity={0.8} color={'#ff9bcf'} />
+      <ProbabilityField simulation={simulation} />
+      <Stars radius={80} depth={40} count={1200} factor={2} saturation={0} fade speed={0.3} />
+      <EffectComposer>
+        <Bloom intensity={0.5} luminanceThreshold={0.2} luminanceSmoothing={0.9} />
+      </EffectComposer>
+      <OrbitControls enableZoom={false} enablePan={false} enableRotate={false} />
+    </Canvas>
+  );
+};

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,0 +1,28 @@
+import { useMarketStore } from '../store/useMarketStore';
+
+export const Timeline = () => {
+  const history = useMarketStore((state) => state.history);
+  const selectedIndex = useMarketStore((state) => state.selectedIndex);
+  const setSelectedIndex = useMarketStore((state) => state.setSelectedIndex);
+  const live = useMarketStore((state) => state.live);
+
+  const maxIndex = Math.max(history.length - 1, 0);
+
+  return (
+    <div className="timeline">
+      <label>Replay Timeline (10m)</label>
+      <input
+        type="range"
+        min={0}
+        max={maxIndex}
+        value={selectedIndex}
+        onChange={(event) => setSelectedIndex(Number(event.target.value))}
+        disabled={live}
+      />
+      <div className="toggle-row">
+        <span className="badge">{live ? 'Streaming' : 'Replaying'}</span>
+        <span className="legend">{history.length} frames buffered</span>
+      </div>
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,156 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Space Grotesk', system-ui, -apple-system, sans-serif;
+  background-color: #05070c;
+  color: #e5f0ff;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(30, 60, 110, 0.25), transparent 55%),
+    radial-gradient(circle at bottom, rgba(10, 20, 40, 0.9), #05070c 60%);
+}
+
+#root {
+  height: 100vh;
+  width: 100vw;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  height: 100vh;
+}
+
+.panel {
+  background: rgba(6, 10, 18, 0.9);
+  border-right: 1px solid rgba(120, 170, 255, 0.15);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.panel h1 {
+  font-size: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #9db9ff;
+}
+
+.panel section {
+  background: rgba(12, 20, 36, 0.7);
+  border: 1px solid rgba(120, 170, 255, 0.15);
+  border-radius: 14px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.panel label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #8fa8e8;
+}
+
+.panel input[type='range'] {
+  width: 100%;
+}
+
+.toggle-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.badge {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #7ef9ff;
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.canvas-wrap {
+  position: relative;
+}
+
+.hud {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  display: grid;
+  gap: 16px;
+  max-width: 420px;
+}
+
+.hud-card {
+  background: rgba(6, 10, 18, 0.6);
+  border: 1px solid rgba(120, 170, 255, 0.2);
+  border-radius: 16px;
+  padding: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.hud-title {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #9db9ff;
+  margin-bottom: 10px;
+}
+
+.stat-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+  color: #d7e6ff;
+}
+
+.regime-bar {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(120, 170, 255, 0.15);
+  overflow: hidden;
+}
+
+.regime-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #7ef9ff, #7a8cff, #ff9bcf);
+}
+
+.confluence-list {
+  display: grid;
+  gap: 6px;
+}
+
+.confluence-item {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: #c7d9ff;
+}
+
+.legend {
+  font-size: 11px;
+  color: #84a3f3;
+  line-height: 1.4;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/simulation/rng.ts
+++ b/src/simulation/rng.ts
@@ -1,0 +1,17 @@
+export const mulberry32 = (seed: number) => {
+  let t = seed;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+export const normal = (random: () => number) => {
+  let u = 0;
+  let v = 0;
+  while (u === 0) u = random();
+  while (v === 0) v = random();
+  return Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+};

--- a/src/simulation/simulation.ts
+++ b/src/simulation/simulation.ts
@@ -1,0 +1,148 @@
+import {
+  ConfluenceContribution,
+  ConfluenceState,
+  DistributionCluster,
+  HorizonFan,
+  Regime,
+  RegimeState,
+  SimulationControls,
+  SimulationState,
+  Ticker,
+} from './types';
+import { mulberry32, normal } from './rng';
+
+const regimes: Regime[] = ['trend', 'chop', 'crash-risk', 'melt-up', 'illiquid'];
+const tickers: Ticker[] = ['AAPL', 'MSFT', 'NVDA', 'AMZN', 'GOOGL', 'META', 'TSLA', 'QQQ'];
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const normalize = (values: number[]) => {
+  const total = values.reduce((sum, val) => sum + val, 0) || 1;
+  return values.map((val) => val / total);
+};
+
+const buildClusters = (random: () => number, stress: number): DistributionCluster[] => {
+  return Array.from({ length: 6 }).map(() => {
+    const spread = 0.25 + random() * 0.55 + stress * 0.2;
+    return {
+      center: [normal(random) * 0.6, normal(random) * 0.6, normal(random) * 0.6],
+      spread,
+      intensity: clamp(0.5 + normal(random) * 0.25 + stress * 0.3, 0.2, 1.2),
+    };
+  });
+};
+
+const buildFans = (entropy: number, stress: number): HorizonFan[] => {
+  const horizons: HorizonFan[] = ['5m', '1h', '1d'].map((horizon, index) => {
+    const base = 0.2 + index * 0.25 + entropy * 0.4 + stress * 0.5;
+    return {
+      horizon: horizon as HorizonFan['horizon'],
+      quantiles: [base * 0.6, base, base * 1.35],
+    };
+  });
+  return horizons;
+};
+
+const buildRegime = (
+  random: () => number,
+  sensitivity: number,
+  stress: number,
+): RegimeState => {
+  const raw = regimes.map((_, index) => {
+    const bias = index === 2 ? stress * 1.4 : index === 3 ? stress * 0.6 : 0.2;
+    return clamp(random() + bias + sensitivity * 0.15, 0.05, 1.8);
+  });
+  const normalized = normalize(raw);
+  const probabilities = regimes.reduce<Record<Regime, number>>((acc, regime, index) => {
+    acc[regime] = normalized[index];
+    return acc;
+  }, {} as Record<Regime, number>);
+
+  return {
+    probabilities,
+    transitionRisk: clamp(0.2 + stress * 0.5 + random() * 0.4, 0, 1),
+  };
+};
+
+const buildConfluence = (
+  random: () => number,
+  controls: SimulationControls,
+  stress: number,
+): ConfluenceState => {
+  const contributions: ConfluenceContribution[] = tickers.map((ticker) => {
+    const factors = {
+      correlationShift: clamp(random() + stress * 0.5, 0, 1),
+      volOfVol: clamp(random() + stress * 0.7, 0, 1),
+      breadth: clamp(random() - stress * 0.2, 0, 1),
+      sentimentShock: clamp(random() + stress * 0.6, 0, 1),
+      liquidity: clamp(1 - random() + stress * 0.3, 0, 1),
+    };
+
+    const weightedScore =
+      factors.correlationShift * controls.weightConfig.correlationShift +
+      factors.volOfVol * controls.weightConfig.volOfVol +
+      factors.breadth * controls.weightConfig.breadth +
+      factors.sentimentShock * controls.weightConfig.sentimentShock +
+      factors.liquidity * controls.weightConfig.liquidity;
+
+    return {
+      ticker,
+      score: weightedScore / 5,
+      factors,
+    };
+  });
+
+  const total =
+    contributions.reduce((sum, item) => sum + item.score, 0) / Math.max(contributions.length, 1);
+  return { total, contributions };
+};
+
+const buildPointField = (
+  random: () => number,
+  clusters: DistributionCluster[],
+  count: number,
+): Float32Array => {
+  const positions = new Float32Array(count * 3);
+  for (let i = 0; i < count; i += 1) {
+    const cluster = clusters[Math.floor(random() * clusters.length)];
+    const dx = normal(random) * cluster.spread + cluster.center[0];
+    const dy = normal(random) * cluster.spread + cluster.center[1];
+    const dz = normal(random) * cluster.spread + cluster.center[2];
+    positions[i * 3] = dx;
+    positions[i * 3 + 1] = dy;
+    positions[i * 3 + 2] = dz;
+  }
+  return positions;
+};
+
+export const createSimulation = (seed = 2040) => {
+  const random = mulberry32(seed);
+  let time = 0;
+
+  return (controls: SimulationControls): SimulationState => {
+    time += 1;
+    const stress = clamp(controls.stressTest + Math.sin(time * 0.02) * 0.1, 0, 1);
+    const entropy = clamp(0.2 + random() * 0.4 + stress * 0.4, 0, 1);
+    const kurtosis = clamp(2.5 + random() * 2 + stress * 3, 1.5, 9);
+    const tailRisk = clamp((kurtosis - 2.5) / 6 + stress * 0.3, 0, 1);
+
+    const clusters = buildClusters(random, stress);
+    const fans = buildFans(entropy, stress);
+    const regime = buildRegime(random, controls.regimeSensitivity, stress);
+    const confluence = buildConfluence(random, controls, stress);
+    const pointField = buildPointField(random, clusters, 1600);
+
+    return {
+      time,
+      entropy,
+      kurtosis,
+      tailRisk,
+      clusters,
+      fans,
+      regime,
+      confluence,
+      pointField,
+    };
+  };
+};

--- a/src/simulation/types.ts
+++ b/src/simulation/types.ts
@@ -1,0 +1,82 @@
+export type Regime =
+  | 'trend'
+  | 'chop'
+  | 'crash-risk'
+  | 'melt-up'
+  | 'illiquid';
+
+export type Horizon = '5m' | '1h' | '1d';
+
+export type Ticker =
+  | 'AAPL'
+  | 'MSFT'
+  | 'NVDA'
+  | 'AMZN'
+  | 'GOOGL'
+  | 'META'
+  | 'TSLA'
+  | 'QQQ';
+
+export interface DistributionCluster {
+  center: [number, number, number];
+  spread: number;
+  intensity: number;
+}
+
+export interface HorizonFan {
+  horizon: Horizon;
+  quantiles: [number, number, number];
+}
+
+export interface RegimeState {
+  probabilities: Record<Regime, number>;
+  transitionRisk: number;
+}
+
+export interface ConfluenceContribution {
+  ticker: Ticker;
+  score: number;
+  factors: {
+    correlationShift: number;
+    volOfVol: number;
+    breadth: number;
+    sentimentShock: number;
+    liquidity: number;
+  };
+}
+
+export interface ConfluenceState {
+  total: number;
+  contributions: ConfluenceContribution[];
+}
+
+export interface SimulationState {
+  time: number;
+  entropy: number;
+  kurtosis: number;
+  tailRisk: number;
+  clusters: DistributionCluster[];
+  fans: HorizonFan[];
+  regime: RegimeState;
+  confluence: ConfluenceState;
+  pointField: Float32Array;
+}
+
+export interface SimulationControls {
+  weightConfig: {
+    correlationShift: number;
+    volOfVol: number;
+    breadth: number;
+    sentimentShock: number;
+    liquidity: number;
+  };
+  regimeSensitivity: number;
+  horizon: Horizon;
+  stressTest: number;
+  motionDamping: number;
+}
+
+export interface SimulationSnapshot {
+  timestamp: number;
+  state: SimulationState;
+}

--- a/src/store/useMarketStore.ts
+++ b/src/store/useMarketStore.ts
@@ -1,0 +1,75 @@
+import { create } from 'zustand';
+import { SimulationControls, SimulationSnapshot, SimulationState } from '../simulation/types';
+import { createSimulation } from '../simulation/simulation';
+
+const simulator = createSimulation(2040);
+
+const defaultControls: SimulationControls = {
+  weightConfig: {
+    correlationShift: 1,
+    volOfVol: 1,
+    breadth: 1,
+    sentimentShock: 1,
+    liquidity: 1,
+  },
+  regimeSensitivity: 0.6,
+  horizon: '1h',
+  stressTest: 0.2,
+  motionDamping: 0.4,
+};
+
+const initialState = simulator(defaultControls);
+
+interface MarketStore {
+  controls: SimulationControls;
+  live: boolean;
+  simulation: SimulationState;
+  history: SimulationSnapshot[];
+  selectedIndex: number;
+  setControl: <K extends keyof SimulationControls>(key: K, value: SimulationControls[K]) => void;
+  setWeight: (key: keyof SimulationControls['weightConfig'], value: number) => void;
+  toggleLive: () => void;
+  setSelectedIndex: (index: number) => void;
+  tick: () => void;
+}
+
+export const useMarketStore = create<MarketStore>((set, get) => ({
+  controls: defaultControls,
+  live: true,
+  simulation: initialState,
+  history: [{ timestamp: Date.now(), state: initialState }],
+  selectedIndex: 0,
+  setControl: (key, value) =>
+    set((state) => ({
+      controls: {
+        ...state.controls,
+        [key]: value,
+      },
+    })),
+  setWeight: (key, value) =>
+    set((state) => ({
+      controls: {
+        ...state.controls,
+        weightConfig: {
+          ...state.controls.weightConfig,
+          [key]: value,
+        },
+      },
+    })),
+  toggleLive: () => set((state) => ({ live: !state.live })),
+  setSelectedIndex: (index) => set(() => ({ selectedIndex: index })),
+  tick: () => {
+    const { controls, history, live } = get();
+    if (!live) {
+      return;
+    }
+    const state = simulator(controls);
+    const snapshot: SimulationSnapshot = { timestamp: Date.now(), state };
+    const nextHistory = [...history, snapshot].slice(-600);
+    set({
+      simulation: state,
+      history: nextHistory,
+      selectedIndex: nextHistory.length - 1,
+    });
+  },
+}));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
### Motivation
- Implement a production-style single-page “Market Observatory” UI that visualizes stochastic probability fields, regime belief, and multi-asset confluence in a deterministic, replayable simulation.
- Provide a separable TypeScript architecture (simulation, store, rendering, UI) so simulated output can be swapped for real-time feeds later.
- Deliver minimal, authoritative UX with horizon-focused fan cones, regime halo, tail-risk cues, and configurable confluence weights and stress testing.

### Description
- Add a deterministic simulation engine in `src/simulation/` including RNG helpers, `createSimulation()` with mixture-like clusters, horizon fan quantiles, HMM-like regime state, kurtosis/tail-risk computation, confluence scoring for tickers, and a point-field generator (`src/simulation/rng.ts`, `src/simulation/simulation.ts`, `src/simulation/types.ts`).
- Add a replay-ready Zustand store `useMarketStore` that holds `SimulationControls`, `SimulationState`, a time-buffered `history`, live/scrub modes and a `tick()` scheduler (`src/store/useMarketStore.ts`).
- Implement the UI components: a left `ControlsPanel` with weight sliders and stress/regime/horizon controls, `Timeline` scrubber, `Hud` overlay summarizing regime/tail/confluence, and `ThreeScene` using `react-three-fiber` to render a volumetric probability sphere, instanced point cloud, fan-cone projections, regime halo, and tail-ring visual cues (`src/components/*`).
- Add app wiring and styling including `App.tsx`, `main.tsx`, `index.html`, `src/index.css`, and Vite/TypeScript config; include `package.json` listing `three`, `@react-three/*`, `react`, `zustand` and dev tooling.
- Add README with module plan, state schema, run steps and notes on swapping in real data and performance considerations.

### Testing
- Attempted dependency install via `npm install`, but it failed with a network/registry error (403 Forbidden fetching `@react-three/drei`), so the app could not be started and no runtime/build tests were run.
- No automated unit or integration tests were present in the scaffold to run after the install failure, so no further automated checks were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eabc8ec94832da1d61faf07f978da)